### PR TITLE
Configure types for CLI flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,12 @@ class ServerlessDeleteLoggroups {
               stage: {
                 usage: 'Stage of the service',
                 shortcut: 's',
+                type: 'string,
               },
               region: {
                 usage: 'Region of the service',
                 shortcut: 'r',
+                type: 'string,
               },
             },
           },


### PR DESCRIPTION
Follows https://www.serverless.com/framework/docs/providers/aws/guide/plugins#defining-options

It's scheduled to be a requirement since v3 release of a Framework

/cc @horike37 